### PR TITLE
workflow: bump checkout and upload-artifact action version

### DIFF
--- a/.github/workflows/codeql_checks.yml
+++ b/.github/workflows/codeql_checks.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/documentation_generation.yml
+++ b/.github/workflows/documentation_generation.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: HTML documentation
         run: doxygen .doxygen/Doxyfile
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: doc/html

--- a/.github/workflows/misspellings_checks.yml
+++ b/.github/workflows/misspellings_checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Check misspellings
       uses: codespell-project/actions-codespell@v1

--- a/.github/workflows/python_client_checks.yml
+++ b/.github/workflows/python_client_checks.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Installing PIP dependencies
       run: |
         pip install pylint
@@ -28,4 +28,3 @@ jobs:
     - name: Lint Python code
       run: |
         pylint --rc tests/setup.cfg tests/application_client/
-

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Clone SDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ledgerHQ/ledger-secure-sdk
           path: sdk
@@ -41,7 +41,7 @@ jobs:
           lcov --directory . -b "$(realpath build/)" --remove coverage.info '*/unit-tests/*' -o coverage.info && \
           genhtml coverage.info -o coverage
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: unit-tests/coverage


### PR DESCRIPTION
upload-aftifact@v3 is deprecated and will failed any workflows still using immediately.

bump from v3 to v4.